### PR TITLE
Preprocess neighborlist

### DIFF
--- a/pinn/io/base.py
+++ b/pinn/io/base.py
@@ -27,7 +27,7 @@ class _datalist(list):
 
 
 def sparse_batch(batch_size, drop_remainder=False, num_parallel_calls=8,
-                 atomic_props=['f_data', 'q_data', 'f_weights']):
+                 atomic_props=['f_data', 'q_data', 'f_weights'], store_n_atoms=True):
     """This returns a dataset operation that transforms single samples
     into sparse batched samples. The atomic_props must include all
     properties that are defined on an atomic basis besides 'coord' and
@@ -38,24 +38,47 @@ def sparse_batch(batch_size, drop_remainder=False, num_parallel_calls=8,
         num_parallel_calls (int): option for map
         atomic_props (list): list of atomic properties
     """
+
     def sparsify(tensors):
+        # Sparsify atoms.
         atom_ind = tf.cast(tf.where(tensors['elems']), tf.int32)
-        ind_1 = atom_ind[:, :1]
-        ind_sp = tf.cumsum(tf.ones(tf.shape(ind_1), tf.int32))-1
-        tensors['ind_1'] = ind_1
-        elems = tf.gather_nd(tensors['elems'], atom_ind)
-        coord = tf.gather_nd(tensors['coord'], atom_ind)
-        tensors['elems'] = elems
-        tensors['coord'] = coord
-        # Optional
+        tensors['ind_1'] = atom_ind[:, :1]
+        tensors['elems'] = tf.gather_nd(tensors['elems'], atom_ind)
+        tensors['coord'] = tf.gather_nd(tensors['coord'], atom_ind)
+
+        # Sparsify pairs.
+        if 'ind_2' in tensors:
+            # Collect all th non-padded indices. In padded pairs, both atom indices are zero.
+            pair_ind = tf.cast(tf.where(tf.reduce_sum(tensors['ind_2'], axis=-1)), tf.int32)
+
+            # Compute the shift in the atom indices for each pair.
+            shift = tf.concat([tf.zeros(1, dtype=tensors['n_atoms'].dtype), tensors['n_atoms'][:-1]], axis=0)
+            tensors['ind_2'] = tensors['ind_2'] + tf.expand_dims(tf.expand_dims(shift, -1), -1)
+
+            # Remove padded indices.
+            tensors['ind_2'] = tf.gather_nd(tensors['ind_2'], pair_ind)
+            tensors['diff'] = tf.gather_nd(tensors['diff'], pair_ind)
+            tensors['dist'] = tf.gather_nd(tensors['dist'], pair_ind)
+
+        # Optional fields.
         for name in atomic_props:
             if name in tensors:
                 tensors[name] = tf.gather_nd(tensors[name], atom_ind)
+
         return tensors
-    return lambda dataset: \
-        dataset.padded_batch(batch_size, tf.data.get_output_shapes(dataset),
-                             drop_remainder=drop_remainder).map(
-                                 sparsify, num_parallel_calls)
+
+    def _store_n_atoms(item):
+        item['n_atoms'] = tf.shape(item['elems'])[0]
+        return item
+
+    def _sparse_batch(dataset):
+        if store_n_atoms:
+            dataset = dataset.map(_store_n_atoms, num_parallel_calls)
+        dataset = dataset.padded_batch(batch_size, tf.data.get_output_shapes(dataset), drop_remainder=drop_remainder)
+        dataset = dataset.map(sparsify, num_parallel_calls)
+        return dataset
+
+    return _sparse_batch
 
 
 def map_nested(fn, nested):

--- a/pinn/networks/__init__.py
+++ b/pinn/networks/__init__.py
@@ -6,6 +6,6 @@ a nested tensors gets updated as input.
 Networks should not define the goals/loss of the model, 
 to allows for the usage of same network structure for different tasks.
 """
-from pinn.networks.pinet import pinet
+from pinn.networks.pinet import pinet, preprocess_dataset_pinet
 from pinn.networks.bpnn import bpnn
 from pinn.networks.lj import lj


### PR DESCRIPTION
- Adds a couple of function `utils.preprocess_dataset_neighbor_list` and `networks.pinet.preprocess_dataset_pinet` that enable computing the neighbor list before applying `sparse_batch`. We can use `Dataset.map(preprocess_dataset_pinet).cache()` for preprocessing with this.
- Modify `sparse_batch` so that it's capable of sparsifying the neighbor list and pairwise distances.